### PR TITLE
Bytte fra shiny::dataTableOutput til DT::DTOutput

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -102,7 +102,7 @@ app_ui <- function() {
             shiny::h2("Auto reports running one year from now"),
             shiny::plotOutput("calendar"),
             shiny::h2("Auto report raw data"),
-            shiny::dataTableOutput("autoreport_data")
+            DT::DTOutput("autoreport_data")
           )
         )
       ),


### PR DESCRIPTION
shiny::dataTableOutput var avgått med døden og var uansett erstattet under-the-hood med DT.